### PR TITLE
Add initial call notes file for July

### DIFF
--- a/30072020.md
+++ b/30072020.md
@@ -1,0 +1,16 @@
+# 30th July, 2020 Identity Server Community Call Notes
+
+* YouTube: [to-be-announced]
+* Next community call: 27th August, 2020 (9.30 AM PST)
+
+## Agenda
+
+* [to-be-announced]
+
+## Blogs from last month
+
+* [to-be-announced]
+
+## Upcoming events
+
+* [to-be-announced]


### PR DESCRIPTION
Add the initial call notes file for the month of July with the next community call date. This can help keep track of the event.